### PR TITLE
Update ReadMe example to use existing version

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ JsonMessageMaker is deployed to my own maven repository:
         <dependency>
             <groupId>de.janmm14</groupId>
             <artifactId>jsonmessagemaker</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>3.1.0</version>
         </dependency>
     </dependencies>
 ```


### PR DESCRIPTION
The example version, `2.0-SNAPSHOT` listed in the ReadMe fails to resolve. Updating to the latest version fixes this issue and helps make the process of getting started just a bit smoother.